### PR TITLE
Removed expect script, Added -y to automate ubuntu installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ None (:
 Works only on Ubuntu(apt-get package) and Fedora (dnf package) related systems right now.
 You need to run the script with root access(sudo).
 
-
+**QUICK INSTALL**
+```
+wget -qO- 'https://raw.githubusercontent.com/mukulhase/AutoVPN/master/autovpn.sh' | sudo bash /dev/stdin email password
+```
 
 *Pull requests and suggestions for improvement are most welcome.*
 

--- a/autovpn.sh
+++ b/autovpn.sh
@@ -60,7 +60,7 @@ fi
 
 if [ ! -e "update-resolv-conf.sh" ];
 then
-	wget https://raw.githubusercontent.com/masterkorp/openvpn-update-resolv-conf/master/update-resolv-conf.sh
+	wget https://raw.githubusercontent.com/mukulhase/openvpn-update-resolv-conf/master/update-resolv-conf.sh
 fi
 chmod +x update-resolv-conf.sh
 

--- a/autovpn.sh
+++ b/autovpn.sh
@@ -22,16 +22,16 @@ command -v openvpn >/dev/null 2>&1 || {
 		dnf install -y openvpn
 	fi
 }
-if command -v apt-get 2&>1; then    # Ubuntu based distros
-	if [ $(dpkg-query -W -f='${Status}' openresolv 2>/dev/null | grep -c "ok installed") -eq 0 ];
-	then
-		apt-get -y install openresolv;
-	fi
-elif command -v dnf 2&>1; then
-	if ! rpm -qa | grep -qw openresolv; then
-	    dnf install -y openresolv
-	fi     # Fedora based distros
-fi
+# if command -v apt-get 2&>1; then    # Ubuntu based distros
+# 	if [ $(dpkg-query -W -f='${Status}' openresolv 2>/dev/null | grep -c "ok installed") -eq 0 ];
+# 	then
+# 		apt-get -y install openresolv;
+# 	fi
+# elif command -v dnf 2&>1; then
+# 	if ! rpm -qa | grep -qw openresolv; then
+# 	    dnf install -y openresolv
+# 	fi     # Fedora based distros
+# fi
 
 cd /etc/openvpn;
 if [ ! -e "ca.crt" ];

--- a/autovpn.sh
+++ b/autovpn.sh
@@ -60,7 +60,7 @@ fi
 
 if [ ! -e "update-resolv-conf.sh" ];
 then
-	wget https://raw.githubusercontent.com/mukulhase/openvpn-update-resolv-conf/master/update-resolv-conf.sh
+	wget https://raw.githubusercontent.com/masterkorp/openvpn-update-resolv-conf/master/update-resolv-conf.sh
 fi
 chmod +x update-resolv-conf.sh
 

--- a/autovpn.sh
+++ b/autovpn.sh
@@ -52,6 +52,10 @@ chmod 600 all.iiit.ac.in.key;
 if [ ! -e "linux_client.conf" ];
 then
 	wget https://vpn.iiit.ac.in/linux_client.conf
+	echo 'auth-user-pass auth.txt'  >> linux_client.conf
+	echo 'script-security 2'  >> linux_client.conf
+	echo 'up "/etc/openvpn/update-resolv-conf.sh"'  >> linux_client.conf
+	echo 'down "/etc/openvpn/update-resolv-conf.sh"' >> linux_client.conf
 fi
 
 if [ ! -e "update-resolv-conf.sh" ];
@@ -66,10 +70,8 @@ passwd=$(echo "$passwd"| sed  's/\$/\\\$/g')
 echo "$usr" > auth.txt
 echo "$passwd" >> auth.txt
 chmod 700 auth.txt
-echo 'auth-user-pass auth.txt'  >> linux_client.conf
-echo 'script-security 2'  >> linux_client.conf
-echo 'up "/etc/openvpn/update-resolv-conf.sh"'  >> linux_client.conf
-echo 'down "/etc/openvpn/update-resolv-conf.sh"' >> linux_client.conf
+
+echo 'alias vpn="cd /etc/openvpn;sudo openvpn --config linux_client.conf"' >> ~/.bash_aliases
 
 openvpn --config linux_client.conf
 


### PR DESCRIPTION
- Removes Expect Script.
- Removes need to type the password every single time.
- Up script can be used to notify the user when vpn connects.
- Gets nameservers pushed by IIIT instead of hardcoded nameserver.